### PR TITLE
OGD-314 Fixing issues found in QA:

### DIFF
--- a/app/uk/gov/hmrc/individualincomedesstub/domain/Employment.scala
+++ b/app/uk/gov/hmrc/individualincomedesstub/domain/Employment.scala
@@ -111,7 +111,7 @@ object EmploymentIncomeResponse {
         employment.startDate.map(parse), employment.endDate.map(parse), desPayFrequency, employment.payments map (DesPayment(_))
       )
       case _ => EmploymentIncomeResponse(
-        None, None, None, None,
+        None, None, Some(employment.employerPayeReference.taxOfficeNumber), Some(employment.employerPayeReference.taxOfficeReference),
         employment.startDate.map(parse), employment.endDate.map(parse), desPayFrequency, employment.payments map (DesPayment(_))
       )
     }

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -26,9 +26,9 @@ uses:
   /employer/{empRef}/employment/{nino}:
     uriParameters:
       empRef:
-        description: The employer PAYE reference number
+        description: The URL encoded employer PAYE reference number
         type: string
-        example: 904/UZ00057
+        example: 904%2FUZ00057
       nino:
         description: The employee National Insurance number
         type: string


### PR DESCRIPTION
- EmploymentIncomeResponse should include empRef even if employer details cannot be found
- Fixing description/example of empRef path parameter in the documentation