### PR TITLE
OGD-314 Fixing the following:

### DIFF
--- a/app/uk/gov/hmrc/individualincomedesstub/domain/Employment.scala
+++ b/app/uk/gov/hmrc/individualincomedesstub/domain/Employment.scala
@@ -106,12 +106,12 @@ object EmploymentIncomeResponse {
       case Some(employer) => EmploymentIncomeResponse(
         Option(employer.organisationDetails.name),
         Option(DesAddress(employer.organisationDetails.address)),
-        employer.empRef.map(_.taxOfficeNumber),
-        employer.empRef.map(_.taxOfficeReference),
+        Some(employment.employerPayeReference.taxOfficeNumber),
+        Some(employment.employerPayeReference.taxOfficeReference),
         employment.startDate.map(parse), employment.endDate.map(parse), desPayFrequency, employment.payments map (DesPayment(_))
       )
       case _ => EmploymentIncomeResponse(
-        None, None, None, None,
+        None, None, Some(employment.employerPayeReference.taxOfficeNumber), Some(employment.employerPayeReference.taxOfficeReference),
         employment.startDate.map(parse), employment.endDate.map(parse), desPayFrequency, employment.payments map (DesPayment(_))
       )
     }

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -26,9 +26,9 @@ uses:
   /employer/{empRef}/employment/{nino}:
     uriParameters:
       empRef:
-        description: The employer PAYE reference number
+        description: The URL encoded employer PAYE reference number
         type: string
-        example: 904/UZ00057
+        example: 904%2FUZ00057
       nino:
         description: The employee National Insurance number
         type: string

--- a/test/component/uk/gov/hmrc/individualincomedesstub/EmploymentIncomeSpec.scala
+++ b/test/component/uk/gov/hmrc/individualincomedesstub/EmploymentIncomeSpec.scala
@@ -106,6 +106,8 @@ class EmploymentIncomeSpec extends BaseSpec {
           |{
           |   "employments":[
           |      {
+          |         "employerDistrictNumber":"123",
+          |         "employerSchemeReference":"AI45678",
           |         "employmentStartDate":"2016-01-01",
           |         "employmentLeavingDate":"2016-06-01",
           |         "payFrequency":"M1",

--- a/test/unit/uk/gov/hmrc/individualincomedesstub/domain/EmploymentSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualincomedesstub/domain/EmploymentSpec.scala
@@ -57,7 +57,7 @@ class EmploymentSpec extends FreeSpec with Matchers {
     }
   }
 
-  "An employment income response should derive itself from an employment without a missing employer" in {
+  "An employment income response should derive itself from an employment with a missing employer" in {
     val employmentStartDate = Option("2020-02-01")
     val employmentEndDate = Option("2020-02-29")
     val employment = Employment(EmpRef("123", "AB12345"), Nino("AB123456C"), employmentStartDate, employmentEndDate, Seq.empty)
@@ -66,8 +66,8 @@ class EmploymentSpec extends FreeSpec with Matchers {
 
     employmentIncomeResponse.employerName shouldBe None
     employmentIncomeResponse.employerAddress shouldBe None
-    employmentIncomeResponse.employerDistrictNumber shouldBe None
-    employmentIncomeResponse.employerSchemeReference shouldBe None
+    employmentIncomeResponse.employerDistrictNumber.getOrElse(fail("missing employerDistrictNumber")) shouldBe employment.employerPayeReference.taxOfficeNumber
+    employmentIncomeResponse.employerSchemeReference.getOrElse(fail("missing employerSchemeReference")) shouldBe employment.employerPayeReference.taxOfficeReference
 
     employmentIncomeResponse.employmentStartDate.get shouldBe toLocalDate(employmentStartDate)
     employmentIncomeResponse.employmentLeavingDate.get shouldBe toLocalDate(employmentEndDate)

--- a/test/unit/uk/gov/hmrc/individualincomedesstub/service/EmploymentIncomeServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualincomedesstub/service/EmploymentIncomeServiceSpec.scala
@@ -58,6 +58,12 @@ class EmploymentIncomeServiceSpec extends WordSpecWithFutures with Matchers with
     }
 
     "return a populated filtered sequence when corresponding employments with payments exist" in new TableDrivenPropertyChecks {
+      def incomeResponse(employment: Employment) = {
+        new EmploymentIncomeResponse(None, None, Some(employment.employerPayeReference.taxOfficeNumber),
+          Some(employment.employerPayeReference.taxOfficeReference), employment.startDate.map(parse),
+          employment.endDate.map(parse), None, employment.payments.map(DesPayment(_)))
+      }
+
       def payment(paymentDate: String) = HmrcPayment(paymentDate, 123.45, 56.78)
 
       val employmentWithPaymentAtEndOfMar = Employment(EmpRef("101", "AB10001"), nino, None, None, Seq(payment("2017-03-31")))
@@ -80,13 +86,10 @@ class EmploymentIncomeServiceSpec extends WordSpecWithFutures with Matchers with
       )
 
       forAll(fixtures) { (exampleInterval, expectedResult) =>
-        await(employmentIncomeService.employments(nino, exampleInterval)) shouldBe (expectedResult map (EmploymentIncomeResponse(_, None)))
+        await(employmentIncomeService.employments(nino, exampleInterval)) shouldBe (expectedResult map (incomeResponse(_)))
       }
-
     }
-
   }
-
 }
 
 trait WordSpecWithFutures extends WordSpecLike {


### PR DESCRIPTION
- EmploymentIncomeResponse should include empRef even if employer details cannot be found
- Fixing description/example of empRef path parameter in the documentation