### PR TITLE
OGD-491 renaming self employment fields:

### DIFF
--- a/app/uk/gov/hmrc/individualincomedesstub/domain/SelfAssessment.scala
+++ b/app/uk/gov/hmrc/individualincomedesstub/domain/SelfAssessment.scala
@@ -26,7 +26,7 @@ import scala.util.matching.Regex.Match
 
 case class SelfAssessmentReturn(selfEmploymentStartDate: Option[LocalDate],
                                 saReceivedDate: LocalDate,
-                                selfEmploymentIncome: Double,
+                                selfEmploymentProfit: Double,
                                 employmentsIncome: Double)
 
 object SelfAssessmentReturn {
@@ -34,7 +34,7 @@ object SelfAssessmentReturn {
     SelfAssessmentReturn(
       saReturnPayload.selfEmploymentStartDate.map(parse(_)),
       parse(saReturnPayload.saReceivedDate),
-      saReturnPayload.selfEmploymentIncome.getOrElse(0.0),
+      saReturnPayload.selfEmploymentProfit.getOrElse(0.0),
       saReturnPayload.employmentsIncome.getOrElse(0.0)
     )
   }
@@ -48,7 +48,7 @@ case class SelfAssessment(nino: Nino,
 
 case class SelfAssessmentReturnData(selfEmploymentStartDate: Option[String],
                                     saReceivedDate: String,
-                                    selfEmploymentIncome: Option[Double],
+                                    selfEmploymentProfit: Option[Double],
                                     employmentsIncome: Option[Double])
 
 case class SelfAssessmentCreateRequest(saReturns: Seq[SelfAssessmentReturnData]) {
@@ -60,7 +60,7 @@ case class SelfAssessmentCreateRequest(saReturns: Seq[SelfAssessmentReturnData])
 
 case class SelfAssessmentResponseReturnData(caseStartDate: Option[LocalDate],
                                             receivedDate: LocalDate,
-                                            incomeFromSelfEmployment: Double,
+                                            profitFromSelfEmployment: Double,
                                             incomeFromAllEmployments: Double)
 
 object SelfAssessmentResponseReturnData {
@@ -68,7 +68,7 @@ object SelfAssessmentResponseReturnData {
     SelfAssessmentResponseReturnData(
       selfAssessmentReturn.selfEmploymentStartDate,
       selfAssessmentReturn.saReceivedDate,
-      selfAssessmentReturn.selfEmploymentIncome,
+      selfAssessmentReturn.selfEmploymentProfit,
       selfAssessmentReturn.employmentsIncome
     )
   }

--- a/resources/public/api/conf/1.0/examples/create-self-assessment-request.json
+++ b/resources/public/api/conf/1.0/examples/create-self-assessment-request.json
@@ -3,13 +3,13 @@
     {
       "selfEmploymentStartDate": "2014-01-01",
       "saReceivedDate": "2015-01-01",
-      "selfEmploymentIncome": 1233.33,
+      "selfEmploymentProfit": 1233.33,
       "employmentsIncome": 13567.77
     },
     {
       "selfEmploymentStartDate": "2015-01-01",
       "saReceivedDate": "2016-01-01",
-      "selfEmploymentIncome": 1338.33,
+      "selfEmploymentProfit": 1338.33,
       "employmentsIncome": 14906.10
     }
   ]

--- a/resources/public/api/conf/1.0/examples/create-self-assessment-response.json
+++ b/resources/public/api/conf/1.0/examples/create-self-assessment-response.json
@@ -5,13 +5,13 @@
     {
       "selfEmploymentStartDate": "2014-01-01",
       "saReceivedDate": "2015-01-01",
-      "selfEmploymentIncome": 1233.33,
+      "selfEmploymentProfit": 1233.33,
       "employmentsIncome": 13567.77
     },
     {
       "selfEmploymentStartDate": "2015-01-01",
       "saReceivedDate": "2016-01-01",
-      "selfEmploymentIncome": 1338.33,
+      "selfEmploymentProfit": 1338.33,
       "employmentsIncome": 14906.10
     }
   ]

--- a/resources/public/api/conf/1.0/schemas/create-self-assessment-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-self-assessment-request.json
@@ -24,8 +24,8 @@
               "description": "The date on which the self assessment was submitted",
               "example": "2016-01-01"
             },
-            "selfEmploymentIncome": {
-              "id": "/properties/saReturns/items/selfEmploymentIncome",
+            "selfEmploymentProfit": {
+              "id": "/properties/saReturns/items/selfEmploymentProfit",
               "type": "number",
               "description": "The income obtained for the self employment",
               "example": "1233.33"

--- a/resources/public/api/conf/1.0/schemas/create-self-assessment-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-self-assessment-response.json
@@ -34,8 +34,8 @@
             "description": "The date in which the self assessment was submitted",
             "example": "2016-01-01"
           },
-          "selfEmploymentIncome": {
-            "id": "/properties/saReturns/items/selfEmploymentIncome",
+          "selfEmploymentProfit": {
+            "id": "/properties/saReturns/items/selfEmploymentProfit",
             "type": "number",
             "description": "The income obtained for the self employment",
             "example": "1233.33"

--- a/test/component/uk/gov/hmrc/individualincomedesstub/SelfAssessmentIncomeSpec.scala
+++ b/test/component/uk/gov/hmrc/individualincomedesstub/SelfAssessmentIncomeSpec.scala
@@ -63,7 +63,7 @@ class SelfAssessmentIncomeSpec extends BaseSpec {
                       {
                           "caseStartDate": "2013-01-01",
                           "receivedDate": "2014-01-01",
-                          "incomeFromSelfEmployment": 100.15,
+                          "profitFromSelfEmployment": 100.15,
                           "incomeFromAllEmployments": 100.15
                       }
                   ]
@@ -74,7 +74,7 @@ class SelfAssessmentIncomeSpec extends BaseSpec {
                       {
                           "caseStartDate": "2013-01-01",
                           "receivedDate": "2015-01-01",
-                          "incomeFromSelfEmployment": 200.20,
+                          "profitFromSelfEmployment": 200.20,
                           "incomeFromAllEmployments": 300.35
                       }
                   ]

--- a/test/component/uk/gov/hmrc/individualincomedesstub/SelfAssessmentSpec.scala
+++ b/test/component/uk/gov/hmrc/individualincomedesstub/SelfAssessmentSpec.scala
@@ -48,13 +48,13 @@ class SelfAssessmentSpec extends BaseSpec {
              {
                "selfEmploymentStartDate": "2014-01-01",
                "saReceivedDate": "2015-01-01",
-               "selfEmploymentIncome": 1233.33,
+               "selfEmploymentProfit": 1233.33,
                "employmentsIncome": 13567.77
              },
              {
                "selfEmploymentStartDate": "2015-01-01",
                "saReceivedDate": "2016-01-01",
-               "selfEmploymentIncome": 1338.33,
+               "selfEmploymentProfit": 1338.33,
                "employmentsIncome": 14906.10
              }
            ]
@@ -91,7 +91,7 @@ class SelfAssessmentSpec extends BaseSpec {
            "saReturns": [
              {
                "saReceivedDate": "2015-01-01",
-               "selfEmploymentIncome": 1233.33,
+               "selfEmploymentProfit": 1233.33,
                "employmentsIncome": 13567.77
              }
            ]
@@ -135,7 +135,7 @@ class SelfAssessmentSpec extends BaseSpec {
       response.code shouldBe CREATED
 
       And("The self assessment is created and returned with default income values")
-      val employment = selfAssessment(saReturns = Seq(selfAssessmentReturn(selfEmploymentIncome = 0.0, employmentsIncome = 0.0)))
+      val employment = selfAssessment(saReturns = Seq(selfAssessmentReturn(selfEmploymentProfit = 0.0, employmentsIncome = 0.0)))
       Json.parse(response.body) shouldBe Json.toJson(employment)
 
       And("The self assessment is stored in mongo")
@@ -193,10 +193,10 @@ class SelfAssessmentSpec extends BaseSpec {
   }
 
   def selfAssessmentReturn(selfEmploymentStartDate: Option[LocalDate] = Some(parse("2014-01-01")),
-                           selfEmploymentIncome: Double = 1233.33,
+                           selfEmploymentProfit: Double = 1233.33,
                            employmentsIncome: Double = 13567.77,
                            saReceivedDate: LocalDate = parse("2015-01-01")) = {
-    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentIncome, employmentsIncome)
+    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentProfit, employmentsIncome)
   }
 
   def selfAssessment(nino: String = ninoString, taxYear: String = taxYearString, saReturns: Seq[SelfAssessmentReturn] = Seq(selfAssessmentReturn())) = {

--- a/test/it/uk/gov/hmrc/individualincomedesstub/repository/SelfAssessmentRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualincomedesstub/repository/SelfAssessmentRepositorySpec.scala
@@ -92,11 +92,11 @@ class SelfAssessmentRepositorySpec  extends UnitSpec with WithFakeApplication wi
   }
 
   def selfAssessmentReturn(selfEmploymentStartDate: Option[LocalDate] = Some(parse("2015-01-01")),
-                           selfEmploymentIncome: Double = 1233.33,
+                           selfEmploymentProfit: Double = 1233.33,
                            employmentsIncome: Double = 13567.77,
                            saReceivedDate: LocalDate = parse("2016-01-01")
                           ) = {
-    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentIncome, employmentsIncome)
+    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentProfit, employmentsIncome)
   }
 
   def selfAssessment(saReturns: Seq[SelfAssessmentReturn] = Seq(selfAssessmentReturn())) = {

--- a/test/unit/uk/gov/hmrc/individualincomedesstub/service/SelfAssessmentIncomeServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualincomedesstub/service/SelfAssessmentIncomeServiceSpec.scala
@@ -64,10 +64,10 @@ class SelfAssessmentIncomeServiceSpec extends UnitSpec with MockitoSugar {
   }
 
   def selfAssessmentReturn(selfEmploymentStartDate: Option[LocalDate] = Some(parse("2014-01-01")),
-                           selfEmploymentIncome: Double = 1233.33,
+                           selfEmploymentProfit: Double = 1233.33,
                            employmentsIncome: Double = 13567.77,
                            saReceivedDate: LocalDate = parse("2015-01-01")) = {
-    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentIncome, employmentsIncome)
+    SelfAssessmentReturn(selfEmploymentStartDate, saReceivedDate, selfEmploymentProfit, employmentsIncome)
   }
 
   def selfAssessment(nino: String = ninoString, taxYear: String = taxYearString, saReturns: Seq[SelfAssessmentReturn] = Seq(selfAssessmentReturn())) = {


### PR DESCRIPTION
- selfEmploymentIncome to selfEmploymentProfit when creating self employments
- incomeFromSelfEmployment to profitFromSelfEmployment when retrieving DES stubbed data