### PR TITLE
DLS-8997 | Config warnings fix, provide defaults in application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,17 +19,6 @@ include "backend.conf"
 
 appName=individual-income-des-stub
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform backend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.individualincomedesstub.controller.CustomErrorHandler"
 
@@ -148,7 +137,9 @@ mongodb {
     uri = "mongodb://localhost:27017/individual-income-des-stub"
 }
 
-api.access.version-1.0 {}
+api.access.version-1.0 {
+    whitelistedApplicationIds = []
+}
 
 microservice {
     services {


### PR DESCRIPTION
Config warning seems to be more strict abt specific fields than the parent block being empty. So, explicitly setting defaults for the fields config warnings have been reported on. 